### PR TITLE
Move PreprocessSNF here from RegisterDriver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,22 +1,25 @@
 name = "RegisterCore"
 uuid = "67712758-55e7-5c3c-8e85-dda1d7758434"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 CenterIndexedArrays = "46a7138f-0d70-54e1-8ada-fb8296f91f24"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 CenterIndexedArrays = "0.2"
 ImageCore = "0.8.1"
 ImageFiltering = "0.5, 0.6"
+Requires = "1"
 julia = "^1.1"
 
 [extras]
+ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Interpolations", "Test"]
+test = ["ImageMetadata", "Interpolations", "Test"]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -20,6 +20,7 @@ separate
 
 ```@docs
 highpass
+PreprocessSNF
 paddedview
 trimmedview
 ```


### PR DESCRIPTION
I'm not sure why this was in RegisterDriver in the first place; this is a far more logical home.

It might also be worth considering moving all the filtering under a `@require` block, but this gets us in the right direction.